### PR TITLE
Convert objects to arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ Description of the file format
 {
   "file_format": "1.0",
   "version":"0.1.0",
-  "matches": {
-    "<<matcher>>": {
+  "matches": [
+    {
+      "match": "<<pattern_to_match>>",
       "description": "<<description>>",
       "comment": "<<comment>>",
-      "flavors": {
-        "<<flavor>>": {
+      "flavors": [
+        {
+          "flavor": "<<flavor_name>>",
           "description": "<<description>>",
           "comment": "<<comment>>",
           "reference": "<<reference>>",
@@ -21,18 +23,18 @@ Description of the file format
             "<<setting>>": "<<value>>"
           }
         }
-      }
+      ]
     }
-  }
+  ]
 }
 ```
 
 Where
 
-* `matcher` stands for the default files-glob the section defines; the format 
+* `match` stands for the default files-glob the section defines; the format 
   should allow to use it to filter the defaults based on a list of files. 
   This is what goes between `[` and `]` in the editorconfig-file.
-* `flavors` stands for the given flavor name; it should be used to let the 
+* `flavor` stands for the given flavor name; it should be used to let the 
   user choose the preferred style; the using tool might omit showing it if 
   there is only one flavor (f.e. `common` or `convention`) for the section.
 * `setting` and `value` are the editorconfig-settings for that flavor; 

--- a/editorconfig-defaults.json
+++ b/editorconfig-defaults.json
@@ -1,12 +1,13 @@
 {
   "schema_version": "0.1",
   "version": "0.1.0",
-  "matches": {
-
-    "*.{yml,yaml}": {
+  "matches": [
+    {
+      "match": "*.{yml,yaml}",
       "description": "YAML",
-      "flavors": {
-        "standard": {
+      "flavors": [
+        {
+          "flavor": "standard",
           "description": "YAML Specification 1.2",
           "comment": "indent_size based on common use",
           "reference": "http://www.yaml.org/spec/1.2/spec.html#Syntax",
@@ -15,13 +16,15 @@
             "indent_size": 2
           }
         }
-      }
+      ]
     },
 
-    "*.js": {
+    {
+      "match": "*.js",
       "description": "JavaScript",
-      "flavors": {
-        "mozilla": {
+      "flavors": [
+        {
+          "flavor": "mozilla",
           "description": "Mozilla Developer Guide Coding Style",
           "reference": "https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style",
           "editorconfig": {
@@ -32,7 +35,8 @@
             "max_line_length": 80
           }
         },
-        "jquery": {
+        {
+          "flavor": "jquery",
           "description": "jQuery Style Guide",
           "reference": "https://contribute.jquery.org/style-guide/js",
           "editorconfig": {
@@ -42,7 +46,8 @@
             "max_line_length": 100
           }
         },
-        "node-felix": {
+        {
+          "flavor": "node-felix",
           "description": "Felix's Node.js Style Guide",
           "reference": "https://github.com/felixge/node-style-guide",
           "editorconfig": {
@@ -55,26 +60,30 @@
             "max_line_length": 80
           }
         }
-      }
+      ]
     },
 
-    "{Makefile,*.mak}": {
+    {
+      "match": "{Makefile,*.mak}",
       "description": "Make",
-      "flavors": {
-        "standard": {
+      "flavors": [
+        {
+          "flavor": "standard",
           "comment": "Make only works with tab indentation",
           "reference": "https://www.gnu.org/software/make/manual/make.html",
           "editorconfig": {
             "indent_style": "tab"
           }
         }
-      }
+      ]
     },
 
-    "*.py": {
+    {
+      "match": "*.py",
       "description": "Python",
-      "flavors": {
-        "pep-8": {
+      "flavors": [
+        {
+          "flavor": "pep-8",
           "description": "PEP 8 - Style Guide for Python Code",
           "reference": "https://www.python.org/dev/peps/pep-0008/",
           "editorconfig": {
@@ -84,13 +93,15 @@
             "max_line_length": 80
           }
         }
-      }
+      ]
     },
 
-    "*.cs": {
+    {
+      "match": "*.cs",
       "description": "C#",
-      "flavors": {
-        "convention": {
+      "flavors": [
+        {
+          "flavor": "convention",
           "description": "Microsoft suggested code convention",
           "reference": "https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions",
           "editorconfig": {
@@ -98,21 +109,23 @@
             "indent_size": 4
           }
         }
-      }
+      ]
     },
 
-    "{*.{csproj,vcxproj,vcxproj.user}}": {
+    {
+      "match": "{*.{csproj,vcxproj,vcxproj.user}}",
       "description": "Visual Studio Project Files",
       "comment": "List of extensions is incomplete",
-      "flavors": {
-        "common": {
+      "flavors": [
+        {
+          "flavor": "common",
           "editorconfig": {
             "indent_style": "space",
             "indent_size": 2,
             "end_of_line": "crlf"
           }
         }
-      }
+      ]
     }
-  }
+  ]
 }

--- a/editorconfig-defaults.schema.json
+++ b/editorconfig-defaults.schema.json
@@ -4,128 +4,116 @@
   "title": "EditorConfig Defaults",
   "type": "object",
   "definitions": {
-    "codeStyleObject": {
+    "matchesObject": {
         "properties": {
-            "description": {
-              "description": "",
-              "type": "string"
-            },
-            "editorconfig": {
-              "$ref": "#/definitions/editorConfigObject",
-              "description": ""
-            },
-            "reference": {
-              "description": "",
-              "type": "string"
+          "match": {
+            "description": "The regular expression to match",
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "flavors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/flavorsObject"
             }
+          }
         },
         "required": [
-          "editorconfig",
-          "reference"
+          "match",
+          "description",
+          "flavors"
         ]
+    },
+    "flavorsObject": {
+      "properties": {
+        "flavor": {
+          "description": "The name of the flavor",
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
+        },
+        "reference": {
+          "description": "The URL where the flavor is described",
+          "type": "string"
+        },
+        "editorconfig": {
+          "$ref": "#/definitions/editorConfigObject"
+        }
+      },
+      "required": [
+        "flavor",
+        "editorconfig"
+      ]
     },
     "editorConfigObject": {
       "properties": {
         "end_of_line": {
           "description": "",
-          "type": "string"
+          "type": "string",
+          "enum": [ "cr", "lf", "crlf" ]
         },
         "indent_size": {
           "description": "",
-          "type": "integer"
+          "type": "integer",
+          "minimum": 1
+        },
+        "tab_width": {
+          "description": "",
+          "type": "integer",
+          "minimum": 1
         },
         "indent_style": {
           "description": "",
-          "type": "string"
+          "type": "string",
+          "enum": [ "space", "tab" ]
+        },
+        "trim_trailing_spaces": {
+          "description": "",
+          "type": "boolean"
+        },
+        "insert_final_newline": {
+          "description": "",
+          "type": "boolean"
+        },
+        "charset": {
+          "description": "",
+          "type": "string",
+          "enum": [ "latin1", "utf-8", "utf-8-bom", "utf-16be", "utf-16le" ]
+        },
+        "max_line_length": {
+          "description": "",
+          "type": "integer"
         }
       },
       "required": []
-    },
-    "flavorsObject": {
-      "properties": {
-        "convention": {
-          "$ref": "#/definitions/codeStyleObject",
-          "description": ""
-        },
-        "standard": {
-          "$ref": "#/definitions/codeStyleObject",
-          "description": ""
-        }
-      },
-      "required": []
-    },
-    "languageObject": {
-      "properties": {
-        "comment": {
-          "description": "",
-          "type": "string"
-        },
-        "description": {
-          "description": "",
-          "type": "string"
-        },
-        "flavors": {
-          "$ref": "#/definitions/flavorsObject",
-          "description": ""
-        }
-      },
-      "required": [
-        "description",
-        "flavors"
-      ]
-    },
-    "matchesObject": {
-      "properties": {
-        "*.cs": {
-          "$ref": "#/definitions/languageObject",
-          "description": ""
-        },
-        "*.js": {
-          "$ref": "#/definitions/languageObject",
-          "description": ""
-        },
-        "*.py": {
-          "$ref": "#/definitions/languageObject",
-          "description": ""
-        },
-        "*.{yml,yaml}": {
-          "$ref": "#/definitions/languageObject",
-          "description": ""
-        },
-        "{*.{csproj,vcxproj,vcxproj.user}}": {
-          "$ref": "#/definitions/languageObject",
-          "description": ""
-        },
-        "{Makefile,*.mak}": {
-          "$ref": "#/definitions/languageObject",
-          "description": ""
-        }
-      },
-      "required": [
-        "*.cs",
-        "*.js",
-        "*.py",
-        "*.{yml,yaml}",
-        "{*.{csproj,vcxproj,vcxproj.user}}",
-        "{Makefile,*.mak}"
-      ]
     }
   },
   "properties": {
+    "version": {
+      "type": "string"
+    },
     "schema_version": {
-      "description": "",
       "type": "string"
     },
     "matches": {
-      "$ref": "#/definitions/matchesObject",
-      "description": ""
-    },
-    "version": {
-      "description": "",
-      "type": "string"
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/matchesObject"
+      }
     }
   },
   "required": [
-    "schema_version"
+    "schema_version",
+    "version",
+    "matches"
   ]
 }


### PR DESCRIPTION
Closes #2, #3, #4 

This PR works towards the initial release of the `editorconfig-defaults.json` file.

`matches` and `flavors` are now arrays instead of objects. This makes the schema a lot less complicated and easier to validate.

@florianb and/or @deinok could you please review this PR?